### PR TITLE
Fix helm chart repository URL for VMware Tanzu Velero

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -826,8 +826,8 @@ traefik:
 	v.SetDefault("cluster::disasterRecovery::ark::restoreSyncInterval", "20s")
 	v.SetDefault("cluster::disasterRecovery::ark::backupSyncInterval", "20s")
 	v.SetDefault("cluster::disasterRecovery::ark::restoreWaitTimeout", "5m")
-	v.SetDefault("cluster::disasterRecovery::charts::ark::chart", "banzaicloud-stable/velero")
-	v.SetDefault("cluster::disasterRecovery::charts::ark::version", "2.23.6-bc.2")
+	v.SetDefault("cluster::disasterRecovery::charts::ark::chart", "vmware-tanzu/velero")
+	v.SetDefault("cluster::disasterRecovery::charts::ark::version", "2.23.6")
 	v.SetDefault("cluster::disasterRecovery::charts::ark::values", map[string]interface{}{
 		"image": map[string]interface{}{
 			"repository": "velero/velero",
@@ -873,6 +873,7 @@ traefik:
 	v.SetDefault("helm::repositories::bitnami", "https://charts.bitnami.com/bitnami")
 	v.SetDefault("helm::repositories::loki", "https://grafana.github.io/helm-charts")
 	v.SetDefault("helm::repositories::prometheus-community", "https://prometheus-community.github.io/helm-charts")
+	v.SetDefault("helm::repositories::vmware-tanzu", "https://vmware-tanzu.github.io/helm-charts")
 
 	// Cloud configuration
 	v.SetDefault("cloud::amazon::defaultRegion", "us-west-1")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
This PR updates the default chart and version for disaster recovery charts in the Traefik configuration. It changes the chart from "banzaicloud-stable/velero" to "vmware-tanzu/velero" and updates the version to "2.23.6".

### Why?
This PR is made to keep the disaster recovery charts up to date and aligned with the latest chart version from VMware Tanzu. 

### Additional context
No additional context is needed for this PR.

### Checklist
- [ ] Implementation tested (with at least one cloud provider)
- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] OpenAPI and Postman files updated (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here

Generated by Panoptica