### PR TITLE
Update Loki Helm chart repository URL

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -871,7 +871,7 @@ traefik:
 	v.SetDefault("helm::repositories::stable", "https://charts.helm.sh/stable")
 	v.SetDefault("helm::repositories::banzaicloud-stable", "https://kubernetes-charts.banzaicloud.com")
 	v.SetDefault("helm::repositories::bitnami", "https://charts.bitnami.com/bitnami")
-	v.SetDefault("helm::repositories::loki", "https://grafana.github.io/loki/charts")
+	v.SetDefault("helm::repositories::loki", "https://grafana.github.io/helm-charts")
 	v.SetDefault("helm::repositories::prometheus-community", "https://prometheus-community.github.io/helm-charts")
 
 	// Cloud configuration


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | No
| New feature?    | No
| API breaks?     | No
| Deprecations?   | No
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
This pull request updates the `config.go` file. Specifically, it changes the URL for the `loki` helm repository from `https://grafana.github.io/loki/charts` to `https://grafana.github.io/helm-charts`. This update ensures that the correct repository is used for the `loki` helm charts.

### Why?
This change is made to fix a potential issue where the incorrect URL was being used for the `loki` helm repository. By updating the URL, the correct repository is used, which ensures the availability of the latest `loki` helm charts.

### Additional context
No additional context is needed for this pull request.

### Checklist
- [ ] Implementation tested (with at least one cloud provider)
- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] OpenAPI and Postman files updated (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
No additional tasks remain to be done for this pull request.

Generated by Panoptica