### PR TITLE
Update VMware Tanzu Velero chart and repositories

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -826,8 +826,8 @@ traefik:
 	v.SetDefault("cluster::disasterRecovery::ark::restoreSyncInterval", "20s")
 	v.SetDefault("cluster::disasterRecovery::ark::backupSyncInterval", "20s")
 	v.SetDefault("cluster::disasterRecovery::ark::restoreWaitTimeout", "5m")
-	v.SetDefault("cluster::disasterRecovery::charts::ark::chart", "banzaicloud-stable/velero")
-	v.SetDefault("cluster::disasterRecovery::charts::ark::version", "2.23.6-bc.2")
+	v.SetDefault("cluster::disasterRecovery::charts::ark::chart", "vmware-tanzu/velero")
+	v.SetDefault("cluster::disasterRecovery::charts::ark::version", "2.23.6")
 	v.SetDefault("cluster::disasterRecovery::charts::ark::values", map[string]interface{}{
 		"image": map[string]interface{}{
 			"repository": "velero/velero",
@@ -873,6 +873,7 @@ traefik:
 	v.SetDefault("helm::repositories::bitnami", "https://charts.bitnami.com/bitnami")
 	v.SetDefault("helm::repositories::loki", "https://grafana.github.io/helm-charts")
 	v.SetDefault("helm::repositories::prometheus-community", "https://prometheus-community.github.io/helm-charts")
+	v.SetDefault("helm::repositories::vmware-tanzu", "https://vmware-tanzu.github.io/helm-charts")
 
 	// Cloud configuration
 	v.SetDefault("cloud::amazon::defaultRegion", "us-west-1")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
This pull request updates the default chart and version values for the Ark disaster recovery tool in the Traefik configuration. It changes the chart to "vmware-tanzu/velero" and the version to "2.23.6". 

### Why?
This change is made to align with the latest updates and to ensure compatibility with the desired version of Velero.

### Additional context
None

### Checklist
- [x] Implementation tested (with at least one cloud provider)
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] OpenAPI and Postman files updated (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
None

Generated by Panoptica