### PR TITLE
Update Loki repository URL

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -871,7 +871,7 @@ traefik:
 	v.SetDefault("helm::repositories::stable", "https://charts.helm.sh/stable")
 	v.SetDefault("helm::repositories::banzaicloud-stable", "https://kubernetes-charts.banzaicloud.com")
 	v.SetDefault("helm::repositories::bitnami", "https://charts.bitnami.com/bitnami")
-	v.SetDefault("helm::repositories::loki", "https://grafana.github.io/loki/charts")
+	v.SetDefault("helm::repositories::loki", "https://grafana.github.io/helm-charts")
 	v.SetDefault("helm::repositories::prometheus-community", "https://prometheus-community.github.io/helm-charts")
 
 	// Cloud configuration


### PR DESCRIPTION
| Q                 | A   |
| ---------------   | --- |
| Bug fix?          | no  |
| New feature?      | no  |
| API breaks?       | no  |
| Deprecations?     | no  |
| Related tickets   | fixes #X, partially #Y, mentioned in #Z |
| License           | Apache 2.0 |


### What's in this PR?
This pull request updates the default Loki Helm repository URL in the config file from "https://grafana.github.io/loki/charts" to "https://grafana.github.io/helm-charts". 

### Why?
The existing Loki Helm repository URL is outdated and needs to be updated to the latest one.

### Additional context
No additional context is required for this PR.

### Checklist
- [ ] Implementation tested (with at least one cloud provider)
- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] OpenAPI and Postman files updated (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
No tasks remaining.

Generated by Panoptica