### PR TITLE
Fix incorrect Loki helm chart URL

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -871,7 +871,7 @@ traefik:
 	v.SetDefault("helm::repositories::stable", "https://charts.helm.sh/stable")
 	v.SetDefault("helm::repositories::banzaicloud-stable", "https://kubernetes-charts.banzaicloud.com")
 	v.SetDefault("helm::repositories::bitnami", "https://charts.bitnami.com/bitnami")
-	v.SetDefault("helm::repositories::loki", "https://grafana.github.io/loki/charts")
+	v.SetDefault("helm::repositories::loki", "https://grafana.github.io/helm-charts")
 	v.SetDefault("helm::repositories::prometheus-community", "https://prometheus-community.github.io/helm-charts")
 
 	// Cloud configuration


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
This pull request updates the default Helm repository URLs for the `loki` chart. It changes the URL from `https://grafana.github.io/loki/charts` to `https://grafana.github.io/helm-charts`. This update ensures that the latest version of the `loki` chart is used when deploying.

### Why?
This change is made to fix the default repository URL for the `loki` chart, as the previous URL was incorrect.

### Additional context
N/A

### Checklist
- [ ] Implementation tested (with at least one cloud provider)
- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] OpenAPI and Postman files updated (if needed)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
N/A

Generated by Panoptica