### PR TITLE
Fix outdated Loki repository URL

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -871,7 +871,7 @@ traefik:
 	v.SetDefault("helm::repositories::stable", "https://charts.helm.sh/stable")
 	v.SetDefault("helm::repositories::banzaicloud-stable", "https://kubernetes-charts.banzaicloud.com")
 	v.SetDefault("helm::repositories::bitnami", "https://charts.bitnami.com/bitnami")
-	v.SetDefault("helm::repositories::loki", "https://grafana.github.io/loki/charts")
+	v.SetDefault("helm::repositories::loki", "https://grafana.github.io/helm-charts")
 	v.SetDefault("helm::repositories::prometheus-community", "https://prometheus-community.github.io/helm-charts")
 
 	// Cloud configuration


### PR DESCRIPTION
PR Description: Updated the Loki Helm repository URL to https://grafana.github.io/helm-charts to fix broken links. This change is necessary for proper integration with Grafana and ensures that the correct Helm chart is used during deployment. 

To test the change, run the application and verify that the Loki chart is successfully fetched from the new URL. 

Context: The previous URL (https://grafana.github.io/loki/charts) was outdated and no longer maintained. 

No breaking changes are expected with this update.

Generated by Panoptica