### PR TITLE
Update Loki chart URL

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -871,7 +871,7 @@ traefik:
 	v.SetDefault("helm::repositories::stable", "https://charts.helm.sh/stable")
 	v.SetDefault("helm::repositories::banzaicloud-stable", "https://kubernetes-charts.banzaicloud.com")
 	v.SetDefault("helm::repositories::bitnami", "https://charts.bitnami.com/bitnami")
-	v.SetDefault("helm::repositories::loki", "https://grafana.github.io/loki/charts")
+	v.SetDefault("helm::repositories::loki", "https://grafana.github.io/helm-charts")
 	v.SetDefault("helm::repositories::prometheus-community", "https://prometheus-community.github.io/helm-charts")
 
 	// Cloud configuration


### PR DESCRIPTION
Purpose: Update Loki Helm chart repository URL to new location.
Overview: The PR updates the Loki Helm chart repository URL from "https://grafana.github.io/loki/charts" to "https://grafana.github.io/helm-charts" in the config.go file.
Reason: The previous URL for Loki Helm chart repository is outdated and needs to be updated to the new location.
Testing: Verify that the Loki Helm chart repository URL is correctly updated in the code and that the application can fetch the charts from the new URL.
Context: This change is necessary for using the latest version of the Loki Helm chart.
Breaking Changes: None.
Additional Information: The update ensures compatibility with the current Loki Helm chart repository.

Generated by Panoptica